### PR TITLE
Fix UseCases namespace typo

### DIFF
--- a/NewProject.Application/NewProject.Application.csproj
+++ b/NewProject.Application/NewProject.Application.csproj
@@ -72,8 +72,8 @@
     <Compile Include="Interfaces\Managers\IIOManager.cs" />
     <Compile Include="Interfaces\Settings\ISettingService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="UseCasese\Setting\LoadSettingUseCase.cs" />
-    <Compile Include="UseCasese\Setting\SaveSettingUseCase.cs" />
+    <Compile Include="UseCases\Setting\LoadSettingUseCase.cs" />
+    <Compile Include="UseCases\Setting\SaveSettingUseCase.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NewProject.Domain\NewProject.Domain.csproj">
@@ -82,7 +82,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="UseCasese\Inspection\" />
+    <Folder Include="UseCases\Inspection\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/NewProject.Application/UseCases/Setting/LoadSettingUseCase.cs
+++ b/NewProject.Application/UseCases/Setting/LoadSettingUseCase.cs
@@ -6,20 +6,25 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace NewProject.Application.UseCasese.Setting
+namespace NewProject.Application.UseCases.Setting
 {
-	public class SaveSettingUseCase
+	public class LoadSettingUseCase
 	{
 		private readonly ISettingRepository _settingRepository;
 
-		public SaveSettingUseCase(ISettingRepository sr)
+		public LoadSettingUseCase(ISettingRepository sr)
 		{
 			_settingRepository = sr;
+
 		}
 
-		public void Execute(AppSettings entity)
+		public AppSettings Execute()
 		{
-			_settingRepository.Save(entity);
+			var entity = _settingRepository.Load();
+			return new AppSettings
+			{
+				Title = entity.Title
+			};
 		}
 	}
 }

--- a/NewProject.Application/UseCases/Setting/SaveSettingUseCase.cs
+++ b/NewProject.Application/UseCases/Setting/SaveSettingUseCase.cs
@@ -6,25 +6,20 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace NewProject.Application.UseCasese.Setting
+namespace NewProject.Application.UseCases.Setting
 {
-	public class LoadSettingUseCase
+	public class SaveSettingUseCase
 	{
 		private readonly ISettingRepository _settingRepository;
 
-		public LoadSettingUseCase(ISettingRepository sr)
+		public SaveSettingUseCase(ISettingRepository sr)
 		{
 			_settingRepository = sr;
-
 		}
 
-		public AppSettings Execute()
+		public void Execute(AppSettings entity)
 		{
-			var entity = _settingRepository.Load();
-			return new AppSettings
-			{
-				Title = entity.Title
-			};
+			_settingRepository.Save(entity);
 		}
 	}
 }

--- a/NewProject/Bootstrap/AppBootstrapper.cs
+++ b/NewProject/Bootstrap/AppBootstrapper.cs
@@ -1,6 +1,6 @@
 ﻿using CvsSIService.Logger.Services;
 using NewProject.Application.Interfaces.Bootstrap;
-using NewProject.Application.UseCasese.Setting;
+using NewProject.Application.UseCases.Setting;
 using NewProject.Domain.Interfaces.Repository;
 using NewProject.Infratructure.Cameras.Modules;
 using NewProject.Infratructure.Inspections.Modules;

--- a/UI.Dialogs.Setting/ViewModels/Controls/AppSettingViewModel.cs
+++ b/UI.Dialogs.Setting/ViewModels/Controls/AppSettingViewModel.cs
@@ -1,4 +1,4 @@
-﻿using NewProject.Application.UseCasese.Setting;
+﻿using NewProject.Application.UseCases.Setting;
 using NewProject.Domain.Entities.Settings;
 using Prism.Commands;
 using Prism.Mvvm;


### PR DESCRIPTION
## Summary
- fix mis-typed namespace `UseCasese` -> `UseCases`
- update csproj paths and using directives
- keep empty Inspection folder for Visual Studio

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe7b64d348328b28106c231b2ebd0